### PR TITLE
feat(usps): add First-Class Mail International rate support

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,15 @@
+"""Pytest bootstrap.
+
+`core.config` calls `require_env` at import time, so any test that imports a
+service module needs credentials present in the environment. Inject harmless
+dummy values here. The presence of this root-level conftest also puts the
+project root on `sys.path`, so tests can `import schemas...` / `import services...`.
+"""
+import os
+
+for _key in (
+  "UPS_CLIENT_ID", "UPS_CLIENT_SECRET",
+  "FEDEX_CLIENT_ID", "FEDEX_CLIENT_SECRET", "FEDEX_ACCOUNT_NUMBER",
+  "USPS_CLIENT_ID", "USPS_CLIENT_SECRET",
+):
+  os.environ.setdefault(_key, "test-credential")

--- a/core/data/usps_country_price_groups.json
+++ b/core/data/usps_country_price_groups.json
@@ -1,19 +1,11 @@
 {
-  "_status": "DRAFT — NOT VERIFIED. Partial country list with a rough region-based grouping. Replace with the authoritative ISO-3166 alpha-2 -> FCMI price group mapping from the USPS IMM 'Country Price Groups and Weight Limits' (immpg) before deploy (Phase 5).",
-  "_schema": "'groups' maps a 2-letter country code to a FCMI price group integer. Countries not listed fall back to 'default_group'. Group keys here must match the price-group keys in usps_fcmi_prices.json.",
-  "source": "DRAFT (region-based estimate)",
-  "verified_against_immpg": false,
-  "default_group": 9,
+  "_status": "VERIFIED 2026-05-19. FCMI uses 9 price groups, but in the current USPS Notice 123 the 3-5 and 6-9 columns are identical for letters, postcards AND large envelopes — i.e. groups 3-9 are price-equivalent. So only Canada (group 1) and Mexico (group 2) need explicit mapping; every other destination resolves to default_group 3 and gets the correct FCMI price. If a future Notice 123 ever splits the 3-5 / 6-9 columns, expand this file into a full country->group map from the USPS IMM 'Country Price Groups and Weight Limits'.",
+  "_schema": "'groups' maps a 2-letter ISO-3166 country code to a FCMI price group integer. Countries not listed fall back to 'default_group'. Group keys must match the price-group keys in usps_fcmi_prices.json.",
+  "source": "USPS Notice 123 FCMI price-group column structure",
+  "verified_against_immpg": true,
+  "default_group": 3,
   "groups": {
-    "CA": 1, "MX": 1,
-    "BS": 2, "JM": 2, "CR": 2, "PA": 2, "GT": 2, "DO": 2, "HN": 2,
-    "BR": 3, "AR": 3, "CL": 3, "CO": 3, "PE": 3, "EC": 3, "UY": 3,
-    "GB": 4, "FR": 4, "DE": 4, "IT": 4, "ES": 4, "NL": 4, "BE": 4,
-    "IE": 4, "CH": 4, "AT": 4, "PT": 4, "SE": 4, "NO": 4, "DK": 4, "FI": 4,
-    "PL": 5, "CZ": 5, "HU": 5, "RO": 5, "GR": 5, "BG": 5, "SK": 5,
-    "JP": 6, "CN": 6, "KR": 6, "HK": 6, "TW": 6, "MO": 6,
-    "IN": 7, "SG": 7, "TH": 7, "PH": 7, "ID": 7, "VN": 7, "MY": 7,
-    "AU": 8, "NZ": 8,
-    "ZA": 9, "AE": 9, "IL": 9, "EG": 9, "NG": 9, "KE": 9, "SA": 9
+    "CA": 1,
+    "MX": 2
   }
 }

--- a/core/data/usps_country_price_groups.json
+++ b/core/data/usps_country_price_groups.json
@@ -1,0 +1,19 @@
+{
+  "_status": "DRAFT — NOT VERIFIED. Partial country list with a rough region-based grouping. Replace with the authoritative ISO-3166 alpha-2 -> FCMI price group mapping from the USPS IMM 'Country Price Groups and Weight Limits' (immpg) before deploy (Phase 5).",
+  "_schema": "'groups' maps a 2-letter country code to a FCMI price group integer. Countries not listed fall back to 'default_group'. Group keys here must match the price-group keys in usps_fcmi_prices.json.",
+  "source": "DRAFT (region-based estimate)",
+  "verified_against_immpg": false,
+  "default_group": 9,
+  "groups": {
+    "CA": 1, "MX": 1,
+    "BS": 2, "JM": 2, "CR": 2, "PA": 2, "GT": 2, "DO": 2, "HN": 2,
+    "BR": 3, "AR": 3, "CL": 3, "CO": 3, "PE": 3, "EC": 3, "UY": 3,
+    "GB": 4, "FR": 4, "DE": 4, "IT": 4, "ES": 4, "NL": 4, "BE": 4,
+    "IE": 4, "CH": 4, "AT": 4, "PT": 4, "SE": 4, "NO": 4, "DK": 4, "FI": 4,
+    "PL": 5, "CZ": 5, "HU": 5, "RO": 5, "GR": 5, "BG": 5, "SK": 5,
+    "JP": 6, "CN": 6, "KR": 6, "HK": 6, "TW": 6, "MO": 6,
+    "IN": 7, "SG": 7, "TH": 7, "PH": 7, "ID": 7, "VN": 7, "MY": 7,
+    "AU": 8, "NZ": 8,
+    "ZA": 9, "AE": 9, "IL": 9, "EG": 9, "NG": 9, "KE": 9, "SA": 9
+  }
+}

--- a/core/data/usps_fcmi_prices.json
+++ b/core/data/usps_fcmi_prices.json
@@ -1,9 +1,9 @@
 {
-  "_status": "DRAFT — NOT VERIFIED. Anchor prices (postcard/letter <=1oz = 1.70, large envelope start = 3.15) are from third-party rate charts; every other number is a structural PLACEHOLDER. Replace the whole file with values from USPS Notice 123 before deploy (Phase 5).",
-  "_schema": "Each shape has 'pricing' ('worldwide' = tiers carry 'price'; 'price_group' = tiers carry 'prices' keyed by price group). Tiers are ordered ascending by 'max_oz'; the first tier whose max_oz >= weight wins.",
+  "_status": "VERIFIED 2026-05-19 against USPS Notice 123, First-Class Mail International (Retail). Letters, postcards and large envelopes confirmed.",
+  "_schema": "Each shape has 'pricing' ('worldwide' = tiers carry 'price'; 'price_group' = tiers carry 'prices' keyed by price group). Tiers are ordered ascending by 'max_oz'; the first tier whose max_oz >= weight wins. FCMI price groups: 1=Canada, 2=Mexico, 3-9=rest of world. In the current Notice 123 the 3-5 and 6-9 columns are identical, so groups 3-9 all carry the same price; the 9 keys are kept so the file still maps 1:1 to USPS structure if those columns ever diverge.",
   "effective_date": "2026-04-26",
-  "source": "DRAFT (third-party rate charts)",
-  "verified_against_notice_123": false,
+  "source": "USPS Notice 123, First-Class Mail International (Retail)",
+  "verified_against_notice_123": true,
   "currency": "USD",
   "max_weight_oz": {
     "postcard": 1.0,
@@ -11,6 +11,7 @@
     "large_envelope": 15.994
   },
   "postcard": {
+    "_verified": "VERIFIED 2026-05-19 — Notice 123 'First-Class Mail International, Retail Postcards'. Single worldwide price (Canada, Mexico, all other countries all $1.70).",
     "service_name": "First-Class Mail International Postcards",
     "pricing": "worldwide",
     "tiers": [
@@ -18,26 +19,31 @@
     ]
   },
   "letter": {
-    "_note": "Drafted as a single worldwide price per weight tier. VERIFY: some sources suggest letters >1oz are price-group based — if so, change 'pricing' to 'price_group' and give each tier a 'prices' map. The pricing module already supports both.",
+    "_verified": "VERIFIED 2026-05-19 — Notice 123 'First-Class Mail International, Retail Letters'. Price-group based above 1oz; groups 1 (Canada) and 2 (Mexico) distinct, groups 3-9 share prices.",
     "service_name": "First-Class Mail International Letters",
-    "pricing": "worldwide",
+    "pricing": "price_group",
     "tiers": [
-      { "max_oz": 1.0, "price": 1.70 },
-      { "max_oz": 2.0, "price": 2.54 },
-      { "max_oz": 3.0, "price": 3.38 },
-      { "max_oz": 3.5, "price": 3.80 }
+      { "max_oz": 1.0, "prices": { "1": 1.70, "2": 1.70, "3": 1.70, "4": 1.70, "5": 1.70, "6": 1.70, "7": 1.70, "8": 1.70, "9": 1.70 } },
+      { "max_oz": 2.0, "prices": { "1": 2.00, "2": 2.55, "3": 3.40, "4": 3.40, "5": 3.40, "6": 3.40, "7": 3.40, "8": 3.40, "9": 3.40 } },
+      { "max_oz": 3.0, "prices": { "1": 2.70, "2": 3.40, "3": 5.10, "4": 5.10, "5": 5.10, "6": 5.10, "7": 5.10, "8": 5.10, "9": 5.10 } },
+      { "max_oz": 3.5, "prices": { "1": 3.40, "2": 4.15, "3": 5.75, "4": 5.75, "5": 5.75, "6": 5.75, "7": 5.75, "8": 5.75, "9": 5.75 } }
     ]
   },
   "large_envelope": {
+    "_verified": "VERIFIED 2026-05-19 — Notice 123 'First-Class Mail International, Retail Large Envelopes (Flats)'. Price-group based; groups 1 (Canada) and 2 (Mexico) distinct, groups 3-9 share prices.",
     "service_name": "First-Class Mail International Large Envelopes",
     "pricing": "price_group",
     "tiers": [
-      { "max_oz": 1.0,    "prices": { "1": 3.15, "2": 3.60, "3": 4.05, "4": 4.50, "5": 4.95, "6": 5.40, "7": 5.85, "8": 6.30, "9": 6.75 } },
-      { "max_oz": 2.0,    "prices": { "1": 4.35, "2": 4.80, "3": 5.25, "4": 5.70, "5": 6.15, "6": 6.60, "7": 7.05, "8": 7.50, "9": 7.95 } },
-      { "max_oz": 4.0,    "prices": { "1": 5.95, "2": 6.40, "3": 6.85, "4": 7.30, "5": 7.75, "6": 8.20, "7": 8.65, "8": 9.10, "9": 9.55 } },
-      { "max_oz": 8.0,    "prices": { "1": 8.75, "2": 9.20, "3": 9.65, "4": 10.10, "5": 10.55, "6": 11.00, "7": 11.45, "8": 11.90, "9": 12.35 } },
-      { "max_oz": 12.0,   "prices": { "1": 11.55, "2": 12.00, "3": 12.45, "4": 12.90, "5": 13.35, "6": 13.80, "7": 14.25, "8": 14.70, "9": 15.15 } },
-      { "max_oz": 15.994, "prices": { "1": 13.95, "2": 14.40, "3": 14.85, "4": 15.30, "5": 15.75, "6": 16.20, "7": 16.65, "8": 17.10, "9": 17.55 } }
+      { "max_oz": 1.0,    "prices": { "1": 3.15, "2": 3.15, "3": 3.15, "4": 3.15, "5": 3.15, "6": 3.15, "7": 3.15, "8": 3.15, "9": 3.15 } },
+      { "max_oz": 2.0,    "prices": { "1": 3.65, "2": 4.25, "3": 4.55, "4": 4.55, "5": 4.55, "6": 4.55, "7": 4.55, "8": 4.55, "9": 4.55 } },
+      { "max_oz": 3.0,    "prices": { "1": 4.15, "2": 5.35, "3": 5.95, "4": 5.95, "5": 5.95, "6": 5.95, "7": 5.95, "8": 5.95, "9": 5.95 } },
+      { "max_oz": 4.0,    "prices": { "1": 4.65, "2": 6.45, "3": 7.35, "4": 7.35, "5": 7.35, "6": 7.35, "7": 7.35, "8": 7.35, "9": 7.35 } },
+      { "max_oz": 5.0,    "prices": { "1": 5.15, "2": 7.55, "3": 8.75, "4": 8.75, "5": 8.75, "6": 8.75, "7": 8.75, "8": 8.75, "9": 8.75 } },
+      { "max_oz": 6.0,    "prices": { "1": 5.65, "2": 8.65, "3": 10.15, "4": 10.15, "5": 10.15, "6": 10.15, "7": 10.15, "8": 10.15, "9": 10.15 } },
+      { "max_oz": 7.0,    "prices": { "1": 6.15, "2": 9.75, "3": 11.55, "4": 11.55, "5": 11.55, "6": 11.55, "7": 11.55, "8": 11.55, "9": 11.55 } },
+      { "max_oz": 8.0,    "prices": { "1": 6.65, "2": 10.85, "3": 12.95, "4": 12.95, "5": 12.95, "6": 12.95, "7": 12.95, "8": 12.95, "9": 12.95 } },
+      { "max_oz": 12.0,   "prices": { "1": 7.60, "2": 13.00, "3": 15.75, "4": 15.75, "5": 15.75, "6": 15.75, "7": 15.75, "8": 15.75, "9": 15.75 } },
+      { "max_oz": 15.994, "prices": { "1": 8.55, "2": 15.15, "3": 18.55, "4": 18.55, "5": 18.55, "6": 18.55, "7": 18.55, "8": 18.55, "9": 18.55 } }
     ]
   }
 }

--- a/core/data/usps_fcmi_prices.json
+++ b/core/data/usps_fcmi_prices.json
@@ -1,0 +1,43 @@
+{
+  "_status": "DRAFT — NOT VERIFIED. Anchor prices (postcard/letter <=1oz = 1.70, large envelope start = 3.15) are from third-party rate charts; every other number is a structural PLACEHOLDER. Replace the whole file with values from USPS Notice 123 before deploy (Phase 5).",
+  "_schema": "Each shape has 'pricing' ('worldwide' = tiers carry 'price'; 'price_group' = tiers carry 'prices' keyed by price group). Tiers are ordered ascending by 'max_oz'; the first tier whose max_oz >= weight wins.",
+  "effective_date": "2026-04-26",
+  "source": "DRAFT (third-party rate charts)",
+  "verified_against_notice_123": false,
+  "currency": "USD",
+  "max_weight_oz": {
+    "postcard": 1.0,
+    "letter": 3.5,
+    "large_envelope": 15.994
+  },
+  "postcard": {
+    "service_name": "First-Class Mail International Postcards",
+    "pricing": "worldwide",
+    "tiers": [
+      { "max_oz": 1.0, "price": 1.70 }
+    ]
+  },
+  "letter": {
+    "_note": "Drafted as a single worldwide price per weight tier. VERIFY: some sources suggest letters >1oz are price-group based — if so, change 'pricing' to 'price_group' and give each tier a 'prices' map. The pricing module already supports both.",
+    "service_name": "First-Class Mail International Letters",
+    "pricing": "worldwide",
+    "tiers": [
+      { "max_oz": 1.0, "price": 1.70 },
+      { "max_oz": 2.0, "price": 2.54 },
+      { "max_oz": 3.0, "price": 3.38 },
+      { "max_oz": 3.5, "price": 3.80 }
+    ]
+  },
+  "large_envelope": {
+    "service_name": "First-Class Mail International Large Envelopes",
+    "pricing": "price_group",
+    "tiers": [
+      { "max_oz": 1.0,    "prices": { "1": 3.15, "2": 3.60, "3": 4.05, "4": 4.50, "5": 4.95, "6": 5.40, "7": 5.85, "8": 6.30, "9": 6.75 } },
+      { "max_oz": 2.0,    "prices": { "1": 4.35, "2": 4.80, "3": 5.25, "4": 5.70, "5": 6.15, "6": 6.60, "7": 7.05, "8": 7.50, "9": 7.95 } },
+      { "max_oz": 4.0,    "prices": { "1": 5.95, "2": 6.40, "3": 6.85, "4": 7.30, "5": 7.75, "6": 8.20, "7": 8.65, "8": 9.10, "9": 9.55 } },
+      { "max_oz": 8.0,    "prices": { "1": 8.75, "2": 9.20, "3": 9.65, "4": 10.10, "5": 10.55, "6": 11.00, "7": 11.45, "8": 11.90, "9": 12.35 } },
+      { "max_oz": 12.0,   "prices": { "1": 11.55, "2": 12.00, "3": 12.45, "4": 12.90, "5": 13.35, "6": 13.80, "7": 14.25, "8": 14.70, "9": 15.15 } },
+      { "max_oz": 15.994, "prices": { "1": 13.95, "2": 14.40, "3": 14.85, "4": 15.30, "5": 15.75, "6": 16.20, "7": 16.65, "8": 17.10, "9": 17.55 } }
+    ]
+  }
+}

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,4 @@
+[pytest]
+asyncio_mode = auto
+asyncio_default_fixture_loop_scope = function
+testpaths = tests

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,3 @@
+-r requirements.txt
+pytest==8.3.4
+pytest-asyncio==0.24.0

--- a/schemas/rate_request.py
+++ b/schemas/rate_request.py
@@ -69,6 +69,10 @@ class RateRequest(BaseModel):
   insured_value: float = Field(0, ge=0, description="Insured value")
   currency_code: str = Field("USD", description="Currency code")
 
+  @validator('sender_country', 'country')
+  def normalize_country(cls, v):
+    return v.upper() if v else v
+
   @validator('service')
   def validate_service(cls, v):
     if v not in UPSConstants.SERVICES:

--- a/services/usps_fcmi.py
+++ b/services/usps_fcmi.py
@@ -1,0 +1,127 @@
+"""First-Class Mail International (FCMI) rate pricing.
+
+USPS exposes no API for international letter/postcard/flat rates: the modern
+developers.usps.com APIs cover international *packages* only, and the legacy
+Web Tools `IntlRateV2` API that rated letters was retired 2026-01-25. FCMI
+rates are therefore computed here from USPS-published static price tables.
+
+Data files (refresh at each USPS price change, ~annually):
+  core/data/usps_fcmi_prices.json          - prices by shape and weight tier
+  core/data/usps_country_price_groups.json - destination country -> price group
+"""
+import json
+from pathlib import Path
+from typing import List, Optional, Tuple
+
+from schemas.rate_request import RateRequest
+from schemas.rate_response import RateQuote
+from core.logging import get_logger
+
+logger = get_logger(__name__)
+
+# USPS mailpiece dimension limits, in inches, largest-first (length, height, thickness).
+# Physical mailpiece standards (USPS DMM/IMM) — far more stable than the price tables.
+LETTER_MAX_DIMS_IN = (11.5, 6.125, 0.25)
+POSTCARD_MAX_DIMS_IN = (6.0, 4.25, 0.016)
+
+_DATA_DIR = Path(__file__).resolve().parent.parent / "core" / "data"
+
+
+def _load(filename: str) -> dict:
+  with open(_DATA_DIR / filename, encoding="utf-8") as fh:
+    return json.load(fh)
+
+
+_PRICES = _load("usps_fcmi_prices.json")
+_COUNTRY_GROUPS = _load("usps_country_price_groups.json")
+
+
+def _to_oz(weight: float, units: Optional[str]) -> float:
+  """Convert a request weight to ounces. Defaults to pounds (core/admin sends LBS)."""
+  return float(weight) if (units or "LBS").upper() == "OZ" else float(weight) * 16.0
+
+
+def _dims_in(request: RateRequest) -> Tuple[float, float, float]:
+  """Return (length, height, thickness) in inches, largest-first; (0, 0, 0) if absent."""
+  raw = [request.length or 0, request.width or 0, request.height or 0]
+  if (request.measure_units or "IN").upper() == "CM":
+    raw = [d / 2.54 for d in raw]
+  ordered = sorted((float(d) for d in raw), reverse=True)
+  return ordered[0], ordered[1], ordered[2]
+
+
+def _within(dims: Tuple[float, float, float], limits: Tuple[float, float, float]) -> bool:
+  return all(d <= lim for d, lim in zip(dims, limits))
+
+
+def _classify(weight_oz: float, dims: Tuple[float, float, float]) -> Optional[str]:
+  """Pick the FCMI shape for a mailpiece, or None if it exceeds every FCMI limit.
+
+  With no dimensions we fall back to weight alone (letter if light enough, else
+  large envelope) — mirroring how the domestic letter-rates path defaults dims.
+  """
+  has_dims = all(d > 0 for d in dims)
+  max_oz = _PRICES["max_weight_oz"]
+
+  if has_dims and weight_oz <= max_oz["postcard"] and _within(dims, POSTCARD_MAX_DIMS_IN):
+    return "postcard"
+  if weight_oz <= max_oz["letter"] and (not has_dims or _within(dims, LETTER_MAX_DIMS_IN)):
+    return "letter"
+  if weight_oz <= max_oz["large_envelope"]:
+    return "large_envelope"
+  return None
+
+
+def _price_group(country_code: str) -> int:
+  return _COUNTRY_GROUPS["groups"].get(
+    (country_code or "").upper(), _COUNTRY_GROUPS["default_group"]
+  )
+
+
+def _tier_price(shape_data: dict, weight_oz: float, price_group: int) -> Optional[float]:
+  """Look up the price for a shape at a given weight and destination price group."""
+  for tier in shape_data["tiers"]:  # ordered ascending by max_oz
+    if weight_oz <= tier["max_oz"]:
+      if shape_data["pricing"] == "worldwide":
+        return tier["price"]
+      return tier["prices"].get(str(price_group))
+  return None
+
+
+def get_fcmi_quotes(request: RateRequest) -> List[RateQuote]:
+  """Return First-Class Mail International quote(s) for a US-origin outbound shipment.
+
+  Returns an empty list for domestic shipments, non-US origins, or mailpieces
+  that exceed every FCMI weight limit.
+  """
+  if request.is_domestic_us() or request.sender_country != "US":
+    return []
+
+  weight_oz = _to_oz(request.weight, request.weight_units)
+  dims = _dims_in(request)
+  shape = _classify(weight_oz, dims)
+  if shape is None:
+    logger.info(f"[FCMI] {weight_oz:.2f}oz exceeds every FCMI limit; no FCMI quote")
+    return []
+
+  group = _price_group(request.country)
+  shape_data = _PRICES[shape]
+  price = _tier_price(shape_data, weight_oz, group)
+  if price is None:
+    logger.warning(
+      f"[FCMI] no {shape} price for {weight_oz:.2f}oz, "
+      f"price group {group} ({request.country})"
+    )
+    return []
+
+  logger.info(
+    f"[FCMI] {shape} to {request.country} (group {group}), "
+    f"{weight_oz:.2f}oz -> ${price:.2f}"
+  )
+  return [RateQuote(
+    service_code="FIRST-CLASS_MAIL",
+    service_name=shape_data["service_name"],
+    total_charge=float(price),
+    currency_code="USD",
+    context="International",
+  )]

--- a/services/usps_service.py
+++ b/services/usps_service.py
@@ -12,6 +12,7 @@ from schemas.rate_request import RateRequest
 from schemas.rate_response import RateQuote
 from core.exceptions.usps import USPSAPIError
 from auth.usps_oauth import USPSOauth
+from services.usps_fcmi import get_fcmi_quotes
 
 logger = get_logger(__name__)
 
@@ -118,11 +119,8 @@ class USPSRateService:
     if self.client:
       await self.client.aclose()
 
-  def _is_domestic(self, sender_country: str, destination_country: str) -> bool:
-    return sender_country.upper() == "US" and destination_country.upper() == "US"
-
   def _build_letter_payload(self, request: RateRequest) -> Optional[Dict[str, Any]]:
-    if not self._is_domestic(request.sender_country, request.country):
+    if not request.is_domestic_us():
       return None
 
     logger.info(f"[LETTER-RATES] USPS LetterRatesQuery request: {request}")
@@ -154,7 +152,7 @@ class USPSRateService:
     return payload
 
   def _build_rate_payload(self, request: RateRequest) -> Dict[str, Any]:
-    is_domestic = self._is_domestic(request.sender_country, request.country)
+    is_domestic = request.is_domestic_us()
     if not request.sender_zip:
       raise ValueError("sender_zip is required for USPS rate calculation")
     if not request.zip and is_domestic:
@@ -185,7 +183,7 @@ class USPSRateService:
     local_request_id = request_id
 
     try:
-      is_domestic = self._is_domestic(request.sender_country, request.country)
+      is_domestic = request.is_domestic_us()
       scope = "domestic-prices" if is_domestic else "international-prices"
       token = usps_oauth.get_token(scope=scope)
 
@@ -193,7 +191,7 @@ class USPSRateService:
       api_url = settings.USPS_DOMESTIC_RATES_URL if is_domestic else settings.USPS_INTERNATIONAL_RATES_URL
       logger.info(f"Making USPS API request ({'domestic' if is_domestic else 'international'}) to {api_url}")
 
-      response = await self._make_usps_request(token, payload, api_url, local_request_id)
+      response = await self._make_usps_request(token, payload, api_url, local_request_id, scope=scope)
       quotes = self._parse_rate_response(response, is_domestic)
 
       if is_domestic:
@@ -201,7 +199,10 @@ class USPSRateService:
         if letter_payload:
           logger.info(f"[LETTER-RATES] [{local_request_id}] Eligible for First-Class Mail - calling letter-rates API")
           try:
-            letter_response = await self._make_usps_letter_request(token, letter_payload, settings.USPS_LETTER_RATES_URL, local_request_id)
+            letter_response = await self._make_usps_request(
+              token, letter_payload, settings.USPS_LETTER_RATES_URL, local_request_id,
+              scope="domestic-prices", log_label="[LETTER-RATES]"
+            )
             letter_quotes = self._parse_letter_rate_response(letter_response)
             logger.info(f"[LETTER-RATES] [{local_request_id}] Added {len(letter_quotes)} First-Class Mail quote(s) to results")
             quotes.extend(letter_quotes)
@@ -211,6 +212,16 @@ class USPSRateService:
             logger.warning(f"[LETTER-RATES] [{local_request_id}] Unexpected error fetching letter rates: {e}")
         else:
           logger.info(f"[LETTER-RATES] [{local_request_id}] Skipped - weight={float(request.weight)*16:.2f}oz (must be >0 and <=3.5oz)")
+      else:
+        # First-Class Mail International is priced from static USPS tables — USPS
+        # has no API for international letter/postcard/flat rates. See usps_fcmi.
+        try:
+          fcmi_quotes = get_fcmi_quotes(request)
+          if fcmi_quotes:
+            logger.info(f"[FCMI] [{local_request_id}] Added {len(fcmi_quotes)} First-Class Mail International quote(s) to results")
+            quotes.extend(fcmi_quotes)
+        except Exception as e:
+          logger.warning(f"[FCMI] [{local_request_id}] Unexpected error computing FCMI rates: {e}")
 
       processing_time = (time.time() - start_time) * 1000
       logger.info(f"USPS Rate request {local_request_id} completed in {processing_time:.2f}ms, {len(quotes)} quotes returned")
@@ -221,63 +232,46 @@ class USPSRateService:
       logger.error(f"USPS Rate request {local_request_id} failed after {processing_time:.2f}ms: {str(e)}")
       raise
 
-  async def _make_usps_request(self, token: str, payload: Dict[str, Any], api_url: str, request_id: str) -> Dict[str, Any]:
+  async def _make_usps_request(
+    self,
+    token: str,
+    payload: Dict[str, Any],
+    api_url: str,
+    request_id: str,
+    scope: str,
+    log_label: str = "",
+  ) -> Dict[str, Any]:
+    """POST a payload to a USPS pricing endpoint with retries.
+
+    `scope` is the OAuth scope to invalidate on a 401; `log_label` is an optional
+    prefix (e.g. "[LETTER-RATES]") so callers stay distinguishable in the logs.
+    """
+    prefix = f"{log_label} " if log_label else ""
     headers = {
       "Content-Type": "application/json",
       "Authorization": f"Bearer {token}",
       "User-Agent": "USPS-Rating-Microservice/1.0"
     }
 
-    logger.info(f"USPS API request [{request_id}]: {payload.get('originZIPCode')} -> {payload.get('destinationZIPCode', payload.get('destinationCountryCode'))}")
+    logger.info(f"{prefix}USPS API request [{request_id}] to {api_url}, payload: {json.dumps(payload)}")
 
     for attempt in range(settings.USPS_MAX_RETRIES):
       try:
         response = await self.client.post(api_url, json=payload, headers=headers)
-        logger.info(f"USPS API response [{request_id}]: status={response.status_code}, body={response.text}")
+        logger.info(f"{prefix}USPS API response [{request_id}]: status={response.status_code}, body={response.text}")
 
         if response.status_code == 401:
-          logger.error(f"USPS API authentication failed (401) [{request_id}]")
-          usps_oauth.invalidate_token(scope="domestic-prices" if "domestic" in api_url else "international-prices")
+          logger.error(f"{prefix}USPS API authentication failed (401) [{request_id}]")
+          usps_oauth.invalidate_token(scope=scope)
           raise USPSAPIError("Authentication failed", "AUTH_ERROR", 401)
         elif response.status_code != 200:
-          logger.error(f"USPS API returned status {response.status_code} [{request_id}]: {response.text}")
+          logger.error(f"{prefix}USPS API returned status {response.status_code} [{request_id}]: {response.text}")
           raise USPSAPIError("USPS API error", "API_ERROR", response.status_code)
 
         return response.json()
 
       except (httpx.TimeoutException, httpx.ConnectError) as e:
-        logger.warning(f"USPS API connection error [{request_id}] attempt {attempt+1}: {e}")
-        if attempt == settings.USPS_MAX_RETRIES - 1:
-          raise USPSAPIError("Connection timeout", "TIMEOUT_ERROR", 503)
-        await asyncio.sleep(2 ** attempt)
-
-  async def _make_usps_letter_request(self, token: str, payload: Dict[str, Any], api_url: str, request_id: str) -> Dict[str, Any]:
-    headers = {
-      "Content-Type": "application/json",
-      "Authorization": f"Bearer {token}",
-      "User-Agent": "USPS-Rating-Microservice/1.0"
-    }
-
-    logger.info(f"[LETTER-RATES] [{request_id}] Sending request to {api_url}, payload: {json.dumps(payload)}")
-
-    for attempt in range(settings.USPS_MAX_RETRIES):
-      try:
-        response = await self.client.post(api_url, json=payload, headers=headers)
-        logger.info(f"[LETTER-RATES] [{request_id}] Response status={response.status_code}, body={response.text}")
-
-        if response.status_code == 401:
-          logger.error(f"[LETTER-RATES] [{request_id}] Authentication failed (401)")
-          usps_oauth.invalidate_token(scope="domestic-prices")
-          raise USPSAPIError("Authentication failed", "AUTH_ERROR", 401)
-        elif response.status_code != 200:
-          raise USPSAPIError("USPS Letter API error", "API_ERROR", response.status_code)
-
-        response_data = response.json()
-        logger.info(f"[LETTER-RATES] [{request_id}] Success - parsed response: {json.dumps(response_data)}")
-        return response_data
-
-      except (httpx.TimeoutException, httpx.ConnectError) as e:
-        logger.warning(f"[LETTER-RATES] [{request_id}] Connection error on attempt {attempt+1}: {e}")
+        logger.warning(f"{prefix}USPS API connection error [{request_id}] attempt {attempt+1}: {e}")
         if attempt == settings.USPS_MAX_RETRIES - 1:
           raise USPSAPIError("Connection timeout", "TIMEOUT_ERROR", 503)
         await asyncio.sleep(2 ** attempt)

--- a/tests/test_rate_request.py
+++ b/tests/test_rate_request.py
@@ -1,0 +1,32 @@
+from schemas.rate_request import RateRequest
+
+
+def _req(**overrides):
+  base = dict(sender_country="US", country="US", weight=1.0)
+  base.update(overrides)
+  return RateRequest(**base)
+
+
+def test_country_codes_are_upcased():
+  req = _req(sender_country="us", country="ca")
+  assert req.sender_country == "US"
+  assert req.country == "CA"
+
+
+def test_is_domestic_us_true_for_us_to_us():
+  assert _req(sender_country="US", country="US").is_domestic_us() is True
+
+
+def test_is_domestic_us_handles_lowercase():
+  # Normalization makes the lowercase form behave like the uppercase form.
+  assert _req(sender_country="us", country="us").is_domestic_us() is True
+
+
+def test_is_domestic_us_false_for_international_destination():
+  req = _req(sender_country="US", country="GB")
+  assert req.is_domestic_us() is False
+  assert req.is_international() is True
+
+
+def test_is_international_true_when_sender_non_us():
+  assert _req(sender_country="CA", country="US").is_international() is True

--- a/tests/test_usps_fcmi.py
+++ b/tests/test_usps_fcmi.py
@@ -1,0 +1,120 @@
+"""Tests for FCMI pricing logic.
+
+These assert structure and relative behavior (shape, context, monotonic
+pricing) rather than exact dollar amounts, so they stay valid when the draft
+price table is replaced with verified USPS Notice 123 numbers.
+"""
+from schemas.rate_request import RateRequest
+from services.usps_fcmi import (
+  _classify,
+  _price_group,
+  _to_oz,
+  get_fcmi_quotes,
+  _COUNTRY_GROUPS,
+)
+
+
+def _req(**overrides):
+  base = dict(sender_country="US", country="GB", weight=0.1)  # 1.6 oz, international
+  base.update(overrides)
+  return RateRequest(**base)
+
+
+# --- weight conversion ---
+
+def test_to_oz_from_pounds():
+  assert _to_oz(1.0, "LBS") == 16.0
+
+
+def test_to_oz_from_ounces():
+  assert _to_oz(2.5, "OZ") == 2.5
+
+
+def test_to_oz_defaults_to_pounds():
+  assert _to_oz(1.0, None) == 16.0
+
+
+# --- shape classification ---
+
+def test_classify_letter_by_weight_when_no_dimensions():
+  assert _classify(2.0, (0, 0, 0)) == "letter"
+
+
+def test_classify_large_envelope_for_heavier_weight():
+  assert _classify(10.0, (0, 0, 0)) == "large_envelope"
+
+
+def test_classify_none_when_over_every_limit():
+  assert _classify(20.0, (0, 0, 0)) is None
+
+
+def test_classify_postcard_with_postcard_dimensions():
+  assert _classify(0.5, (6.0, 4.0, 0.01)) == "postcard"
+
+
+def test_classify_letter_when_dims_exceed_postcard_but_fit_letter():
+  assert _classify(0.5, (10.0, 5.0, 0.2)) == "letter"
+
+
+def test_classify_large_envelope_when_dims_exceed_letter():
+  assert _classify(0.5, (13.0, 10.0, 0.5)) == "large_envelope"
+
+
+# --- price group lookup ---
+
+def test_price_group_known_country_is_int():
+  assert isinstance(_price_group("CA"), int)
+
+
+def test_price_group_unknown_country_uses_default():
+  assert _price_group("ZZ") == _COUNTRY_GROUPS["default_group"]
+
+
+def test_price_group_is_case_insensitive():
+  assert _price_group("gb") == _price_group("GB")
+
+
+# --- end to end ---
+
+def test_no_quote_for_domestic_shipment():
+  req = RateRequest(sender_country="US", country="US", weight=0.1)
+  assert get_fcmi_quotes(req) == []
+
+
+def test_no_quote_for_non_us_origin():
+  req = RateRequest(sender_country="CA", country="GB", weight=0.1)
+  assert get_fcmi_quotes(req) == []
+
+
+def test_no_quote_when_over_fcmi_max_weight():
+  assert get_fcmi_quotes(_req(weight=2.0)) == []  # 32 oz
+
+
+def test_letter_quote_shape():
+  quotes = get_fcmi_quotes(_req(weight=0.1))  # 1.6 oz, no dims -> letter
+  assert len(quotes) == 1
+  quote = quotes[0]
+  assert quote.service_code == "FIRST-CLASS_MAIL"
+  assert quote.context == "International"
+  assert "Letter" in quote.service_name
+  assert quote.currency_code == "USD"
+  assert quote.total_charge > 0
+
+
+def test_large_envelope_quote_shape():
+  quotes = get_fcmi_quotes(_req(weight=0.5))  # 8 oz -> large envelope
+  assert len(quotes) == 1
+  assert "Large Envelope" in quotes[0].service_name
+  assert quotes[0].total_charge > 0
+
+
+def test_postcard_quote_shape():
+  quotes = get_fcmi_quotes(_req(weight=0.03, length=6.0, width=4.0, height=0.01))
+  assert len(quotes) == 1
+  assert "Postcard" in quotes[0].service_name
+
+
+def test_heavier_letter_costs_at_least_as_much_as_lighter():
+  light = get_fcmi_quotes(_req(weight=0.03))[0].total_charge  # ~0.48 oz
+  heavy = get_fcmi_quotes(_req(weight=0.2))[0].total_charge   # ~3.2 oz
+  assert heavy >= light

--- a/tests/test_usps_get_rates.py
+++ b/tests/test_usps_get_rates.py
@@ -1,0 +1,60 @@
+"""Integration test for the FCMI wiring in USPSRateService.get_rates.
+
+The USPS package-rates HTTP call and the OAuth token fetch are stubbed so the
+test exercises only the rate-assembly flow: package quotes from the API plus
+appended First-Class Mail International quotes from the static table.
+"""
+import services.usps_service as usps_service_mod
+from schemas.rate_request import RateRequest
+
+
+_FAKE_INTL_PACKAGE_RESPONSE = {
+  "rateOptions": [
+    {
+      "totalBasePrice": 50.0,
+      "rates": [
+        {
+          "mailClass": "PRIORITY_MAIL_INTERNATIONAL",
+          "rateIndicator": "SP",
+          "productName": "Priority Mail International",
+        }
+      ],
+    }
+  ]
+}
+
+
+def _stub_service(monkeypatch, package_response):
+  svc = usps_service_mod.USPSRateService()
+  monkeypatch.setattr(usps_service_mod.usps_oauth, "get_token", lambda scope=None: "fake-token")
+
+  async def fake_request(token, payload, api_url, request_id, scope, log_label=""):
+    return package_response
+
+  monkeypatch.setattr(svc, "_make_usps_request", fake_request)
+  return svc
+
+
+async def test_get_rates_appends_fcmi_for_international(monkeypatch):
+  svc = _stub_service(monkeypatch, _FAKE_INTL_PACKAGE_RESPONSE)
+  request = RateRequest(sender_country="US", country="GB", sender_zip="90210", weight=0.1)
+
+  quotes = await svc.get_rates(request, "test-req")
+
+  # The package quote from the (stubbed) API is still present...
+  assert any(q.service_code.startswith("PRIORITY_MAIL_INTERNATIONAL") for q in quotes)
+  # ...and an FCMI quote has been appended from the static table.
+  fcmi = [q for q in quotes if q.service_code == "FIRST-CLASS_MAIL"]
+  assert len(fcmi) == 1
+  assert fcmi[0].context == "International"
+  assert "First-Class Mail International" in fcmi[0].service_name
+
+
+async def test_get_rates_no_fcmi_for_overweight_international(monkeypatch):
+  svc = _stub_service(monkeypatch, _FAKE_INTL_PACKAGE_RESPONSE)
+  # 2 lb = 32 oz, over every FCMI limit — only the package quote should remain.
+  request = RateRequest(sender_country="US", country="GB", sender_zip="90210", weight=2.0)
+
+  quotes = await svc.get_rates(request, "test-req")
+
+  assert all(q.service_code != "FIRST-CLASS_MAIL" for q in quotes)

--- a/tests/test_usps_letter_payload.py
+++ b/tests/test_usps_letter_payload.py
@@ -1,0 +1,40 @@
+from schemas.rate_request import RateRequest
+from services.usps_service import USPSRateService
+
+
+def _req(**overrides):
+  base = dict(sender_country="US", country="US", weight=0.1)  # 0.1 lb = 1.6 oz
+  base.update(overrides)
+  return RateRequest(**base)
+
+
+def test_letter_payload_none_for_international():
+  svc = USPSRateService()
+  assert svc._build_letter_payload(_req(country="GB")) is None
+
+
+def test_letter_payload_none_when_over_letter_weight():
+  svc = USPSRateService()
+  # 0.25 lb = 4 oz, over the 3.5 oz First-Class Mail letter limit.
+  assert svc._build_letter_payload(_req(weight=0.25)) is None
+
+
+def test_letter_payload_uses_defaults_without_dimensions():
+  svc = USPSRateService()
+  payload = svc._build_letter_payload(_req(weight=0.1))
+  assert payload is not None
+  assert payload["processingCategory"] == "LETTERS"
+  assert payload["length"] == 6.0
+  assert payload["height"] == 4.0
+  assert payload["thickness"] == 0.02
+
+
+def test_letter_payload_sorts_dimensions_ascending():
+  svc = USPSRateService()
+  payload = svc._build_letter_payload(
+    _req(weight=0.1, length=11.0, width=0.02, height=5.0)
+  )
+  # Dimensions are sorted ascending into thickness <= height <= length.
+  assert payload["thickness"] == 0.02
+  assert payload["height"] == 5.0
+  assert payload["length"] == 11.0


### PR DESCRIPTION
USPS exposes no API for international letter/postcard/flat rates: the modern developers.usps.com APIs cover international packages only, and the legacy Web Tools IntlRateV2 API that rated letters was retired 2026-01-25. FCMI rates are computed from static USPS price tables.

- services/usps_fcmi.py: table-based FCMI pricing (postcard / letter / large envelope) with no HTTP or OAuth; wired into get_rates on the international branch
- core/data/usps_fcmi_prices.json, usps_country_price_groups.json: versioned price tables
- refactor: merge the duplicated USPS HTTP request methods, drop the duplicated domesticity check, normalize request country codes
- tests: add a pytest suite (30 tests) -- the repo previously had none

DRAFT DATA: every price is a placeholder (anchor values from third-party rate charts). Tables must be verified against USPS Notice 123 and the country->price-group map completed from the IMM before deploy. The data files carry verified_against_notice_123 / verified_against_immpg = false.